### PR TITLE
Fix: Allow scrolling from outside of text content

### DIFF
--- a/src/app/app.tsx
+++ b/src/app/app.tsx
@@ -17,12 +17,7 @@ export const App = () => {
 				className={[s.toolbar, toolbar.mute ? s.muted : ""].join(" ")}
 				ref={toolbar.ref}
 			>
-				<Toolbar
-					show={toolbar.show}
-					editor={editor}
-					handle={file.handle}
-					setHandle={file.setHandle}
-				/>
+				<Toolbar show={toolbar.show} editor={editor} file={file} />
 			</div>
 			<div className={s.editor}>
 				<EditorComponent setEditor={setEditor} />

--- a/src/app/editor/create.ts
+++ b/src/app/editor/create.ts
@@ -14,6 +14,10 @@ interface Result {
 	editor: Editor;
 }
 
+const getLeftPadding = (container: HTMLDivElement) => {
+	return Math.max((container.clientWidth - 1000) / 2, 24);
+};
+
 export const createEditor = (options: Options): Result => {
 	ensureEditorEnv();
 
@@ -31,10 +35,11 @@ export const createEditor = (options: Options): Result => {
 		cursorWidth: 3,
 		fontFamily: "iA Writer Duo",
 		fontLigatures: true,
-		fontSize: 20,
 		fontWeight: "450",
 		glyphMargin: false,
-		lineDecorationsWidth: 0,
+		lineDecorationsWidth: getLeftPadding(options.editor),
+		disableMonospaceOptimizations: true,
+		fontSize: 20,
 		lineHeight: 40,
 		lineNumbers: "off",
 		minimap: { enabled: false },

--- a/src/app/editor/editor.css
+++ b/src/app/editor/editor.css
@@ -1,9 +1,3 @@
-/* Move scrollbar to screen's right */
-.monaco-editor .decorationsOverviewRuler,
-.monaco-editor .scrollbar.vertical {
-	position: fixed !important;
-}
-
 /* Only smooth caret horizontal movements */
 .monaco-editor .cursors-layer.cursor-smooth-caret-animation > .cursor {
 	transition: left 100ms ease-out;

--- a/src/app/editor/editor.module.css
+++ b/src/app/editor/editor.module.css
@@ -1,8 +1,6 @@
 .container {
-	max-width: 1000px;
+	width: 100%;
 	height: 100%;
-	/* Align with the buttons in toolbar */
-	padding: 0 24px;
 	margin: auto;
 
 	display: flex;

--- a/src/app/toolbar/toolbar.module.css
+++ b/src/app/toolbar/toolbar.module.css
@@ -18,7 +18,7 @@
 
 /* The one with flex, and yes this is Friends reference */
 .body {
-	max-width: 1000px;
+	max-width: calc(1000px + 24px * 2);
 	margin: auto;
 	display: flex;
 	align-items: center;

--- a/src/app/toolbar/toolbar.tsx
+++ b/src/app/toolbar/toolbar.tsx
@@ -1,5 +1,6 @@
 import { useSingleton } from "@tippyjs/react";
 import { TooltipSource } from "../../components/tooltip/tooltip";
+import { HandleState } from "../../file/use-handle";
 import { Editor } from "../editor/type";
 import { ToolbarMenu } from "./menu";
 import { ToolbarOpen } from "./open";
@@ -11,8 +12,7 @@ import { ToolbarVim } from "./vim";
 
 interface Props {
 	editor: Editor | null;
-	handle: FileSystemFileHandle | null;
-	setHandle: (handle: FileSystemFileHandle | null) => void;
+	file: HandleState;
 	/** Always show the toolbar, not only on hover */
 	show: boolean;
 }
@@ -22,10 +22,10 @@ export const Toolbar = (props: Props) => {
 	const body = (
 		<div className={s.body}>
 			<TooltipSource singleton={source} delay={500} />
-			<ToolbarOpen singleton={target} setHandle={props.setHandle} />
+			<ToolbarOpen singleton={target} setHandle={props.file.setHandle} />
 			<ToolbarSave
 				singleton={target}
-				handle={props.handle}
+				handle={props.file.handle}
 				editor={props.editor}
 			/>
 			<ToolbarPreview singleton={target} />


### PR DESCRIPTION
Fix #5 

There are several magic numbers (1000px and 24px). I'll extract them to constants in the next PR (having Preview pane)