### PR TITLE
Chore: Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
 		"postcss": "^8.3.6",
 		"postcss-modules": "^4.2.2",
 		"prettier": "2.4.0",
-		"typescript": "^4.4.3"
+		"typescript": "~4.3.5"
 	},
 	"dependencies": {
 		"@tippyjs/react": "^4.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6418,10 +6418,10 @@ type-fest@^0.20.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.20.2.tgz#1bf207f4b28f91583666cb5fbd327887301cd5f4"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-typescript@^4.4.3:
-  version "4.4.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.3.tgz#bdc5407caa2b109efd4f82fe130656f977a29324"
-  integrity sha512-4xfscpisVgqqDfPaJo5vkd+Qd/ItkoagnHpufr+i2QCHBsNYp+G7UAoyFl8aPtx879u38wPV65rZ8qbGZijalA==
+typescript@~4.3.5:
+  version "4.3.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
+  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Should be no breaking change:
- idb-keyval goes from 5 to 6 but it's mainly about the distribution types that we don't use
- prettier goes up a minor version but let just run it again