### PR TITLE
Fix: Fix toolbar width

### DIFF
--- a/src/components/prefs/prefs-visible.ts
+++ b/src/components/prefs/prefs-visible.ts
@@ -1,0 +1,18 @@
+import { Dispatch, SetStateAction, useState } from "react";
+
+export interface PrefsVisibleState {
+	prefsVisible: boolean;
+	setPrefsVisible: Dispatch<SetStateAction<boolean>>;
+}
+
+// Usually the visibility of a panel should be a local state. However, this is
+// a special case as we need to:
+// - Programatically control this state in other places (e.g. shortcut)
+// - Depend on this state in other places (e.g. toolbar width)
+// Therefore it's intentionally set in user's preferences.
+export const usePrefsVisibleState = (): PrefsVisibleState => {
+	// Just "useState" and not "useStorageState" like other prefs as we don't
+	// need this to persist
+	const [prefsVisible, setPrefsVisible] = useState<boolean>(false);
+	return { prefsVisible, setPrefsVisible };
+};

--- a/src/components/prefs/state.ts
+++ b/src/components/prefs/state.ts
@@ -2,11 +2,13 @@ import { LayoutState, usePrefsLayout } from "./layout";
 import { SizeState, usePrefsSize } from "./size/state";
 import { ThemeState, useThemeState } from "../theme/state";
 import { VimState, usePrefsVim } from "./vim";
+import { PrefsVisibleState, usePrefsVisibleState } from "./prefs-visible";
 
 export interface PrefsState
 	extends ThemeState,
 		VimState,
 		LayoutState,
+		PrefsVisibleState,
 		SizeState {}
 
 export const usePrefs = (): PrefsState => {
@@ -14,5 +16,6 @@ export const usePrefs = (): PrefsState => {
 	const vim = usePrefsVim();
 	const layout = usePrefsLayout();
 	const size = usePrefsSize();
-	return { ...theme, ...vim, ...layout, ...size };
+	const prefsVisible = usePrefsVisibleState();
+	return { ...theme, ...vim, ...layout, ...prefsVisible, ...size };
 };

--- a/src/components/toolbar/prefs.tsx
+++ b/src/components/toolbar/prefs.tsx
@@ -4,7 +4,7 @@ import { Button } from "~/src/components/button/button";
 import { Popover } from "../popover/popover";
 import { PrefsPanel } from "../prefs/panel/panel";
 import { PrefsState } from "../prefs/state";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { SHORTCUTS } from "~src/components/toolbar/shortcuts";
 import { useShortcut } from "~src/components/shortcut/use-shortcut";
 
@@ -14,15 +14,17 @@ interface Props {
 }
 
 export const ToolbarPrefs = (props: Props): JSX.Element => {
-	const [visible, setVisible] = useState(false);
+	const { setPrefsVisible } = props.prefs;
 
-	const toggle = useCallback(() => setVisible((v) => !v), [setVisible]);
+	const toggle = useCallback(() => {
+		setPrefsVisible((visible) => !visible);
+	}, [setPrefsVisible]);
 
 	useShortcut(SHORTCUTS.prefs, toggle);
 
 	return (
 		<Popover
-			visible={visible}
+			visible={props.prefs.prefsVisible}
 			onClickOutside={toggle}
 			content={<PrefsPanel prefs={props.prefs} />}
 		>

--- a/src/components/toolbar/toolbar.tsx
+++ b/src/components/toolbar/toolbar.tsx
@@ -1,4 +1,5 @@
 import { useSingleton } from "@tippyjs/react";
+import { useEffect, useState } from "react";
 import { Editor } from "~/src/components/editor/state/state";
 import { FileState } from "~/src/components/file/state";
 import { TooltipSource } from "~/src/components/tooltip/tooltip";
@@ -20,12 +21,29 @@ interface Props {
 	show: boolean;
 }
 
+const useToolbarMaxWidth = (props: Props): number => {
+	const { prefsVisible, size } = props.prefs;
+
+	const [width, setWidth] = useState(1000);
+
+	useEffect(() => {
+		getContentWidth({ size });
+		// Don't update toolbar's width if prefs panel is visible, to avoid
+		// the laggy experience when the user changes the editor size via the
+		// slider
+		if (prefsVisible) return;
+		setWidth(getContentWidth({ size }));
+	}, [prefsVisible, size]);
+
+	return width;
+};
+
 export const Toolbar = (props: Props): JSX.Element => {
 	const [source, target] = useSingleton();
-	const size = props.prefs.size;
+	const maxWidth = useToolbarMaxWidth(props);
 
 	const body = (
-		<div className={s.body} style={{ maxWidth: getContentWidth({ size }) }}>
+		<div className={s.body} style={{ maxWidth }}>
 			<TooltipSource singleton={source} />
 			<ToolbarOpen singleton={target} file={props.file} editor={props.editor} />
 			<ToolbarSave singleton={target} file={props.file} editor={props.editor} />


### PR DESCRIPTION
Previously, the toolbar (max) width is updated when the editor size is changed. This commit keeps the toolbar width unchanged if the prefs panel is visible. This prevents the layout shift when the user changes the editor size, especially via a slider.


https://user-images.githubusercontent.com/5953369/134000872-299ed38f-2162-4e22-8e65-832623f77f75.mov

