### PR TITLE
Added save ability for Web (Fix #143 & Fix #145)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@parcel/transformer-sass": "^2.7.0",
         "@types/react": "^18.0.15",
         "@types/react-dom": "^18.0.6",
+        "@types/wicg-file-system-access": "^2020.9.5",
         "@typescript-eslint/eslint-plugin": "^5.32.0",
         "@typescript-eslint/parser": "^5.32.0",
         "buffer": "^6.0.3",
@@ -1934,6 +1935,12 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.50.tgz",
       "integrity": "sha512-WxV9pLn1XOVMmdflpft88cIXkhl/vi9k7xWEcFWrporpv4/wJq1W/MRyxJbP1npAZqaUNIIw0cH3/3Brgssyjw=="
+    },
+    "node_modules/@types/wicg-file-system-access": {
+      "version": "2020.9.5",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.5.tgz",
+      "integrity": "sha512-UYK244awtmcUYQfs7FR8710MJcefL2WvkyHMjA8yJzxd1mo0Gfn88sRZ1Bls7hiUhA2w7ne1gpJ9T5g3G0wOyA==",
+      "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.32.0",
@@ -8644,6 +8651,12 @@
       "version": "0.0.50",
       "resolved": "https://registry.npmjs.org/@types/web/-/web-0.0.50.tgz",
       "integrity": "sha512-WxV9pLn1XOVMmdflpft88cIXkhl/vi9k7xWEcFWrporpv4/wJq1W/MRyxJbP1npAZqaUNIIw0cH3/3Brgssyjw=="
+    },
+    "@types/wicg-file-system-access": {
+      "version": "2020.9.5",
+      "resolved": "https://registry.npmjs.org/@types/wicg-file-system-access/-/wicg-file-system-access-2020.9.5.tgz",
+      "integrity": "sha512-UYK244awtmcUYQfs7FR8710MJcefL2WvkyHMjA8yJzxd1mo0Gfn88sRZ1Bls7hiUhA2w7ne1gpJ9T5g3G0wOyA==",
+      "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
       "version": "5.32.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@parcel/transformer-sass": "^2.7.0",
     "@types/react": "^18.0.15",
     "@types/react-dom": "^18.0.6",
+    "@types/wicg-file-system-access": "^2020.9.5",
     "@typescript-eslint/eslint-plugin": "^5.32.0",
     "@typescript-eslint/parser": "^5.32.0",
     "buffer": "^6.0.3",

--- a/src/web/app/app.tsx
+++ b/src/web/app/app.tsx
@@ -12,7 +12,7 @@ import { AppTheme } from "./theme";
 
 export const App = (): JSX.Element => {
   const [layout, setLayout] = useState<Layout>("editor");
-  const [doc, setDoc] = useState<Doc>({ path: null, content: "" });
+  const [doc, setDoc] = useState<Doc>({ handle: null, content: "" });
   const [editor, setEditor] = useState<Editor | null>(null);
   const { setSettings, settings } = useSettingsState();
 

--- a/src/web/doc/type.ts
+++ b/src/web/doc/type.ts
@@ -1,21 +1,25 @@
 import { Dispatch, SetStateAction } from "react";
 
+interface DocHandleMac {
+  type: "mac";
+  path: string;
+}
+
+interface DocHandleWeb {
+  type: "web";
+  handle: FileSystemFileHandle;
+}
+
 export interface Doc {
-  /**
-   * null: Not saved yet
-   */
-  path?: string | null;
-  /**
-   * This is like path but for the Web Version.
-   * File Access System API is still experimental. 
-   * Typescript doesn't yet support it. But here's the doc: https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle
-   */
-   fileHandle?: any,
   /**
    * This is NOT the current value of the editor. This is the content of the
    * document when we load it, or since last save.
    */
   content: string;
+  /**
+   * null: not saved
+   */
+  handle: null | DocHandleWeb | DocHandleMac;
 }
 
 export interface DocState {

--- a/src/web/doc/type.ts
+++ b/src/web/doc/type.ts
@@ -6,6 +6,12 @@ export interface Doc {
    */
   path: string | null;
   /**
+   * This is like path but for the Web Version.
+   * File Access System API is still experimental. 
+   * Typescript doesn't yet support it. But here's the doc: https://developer.mozilla.org/en-US/docs/Web/API/FileSystemFileHandle
+   */
+   fileHandle?: any,
+  /**
    * This is NOT the current value of the editor. This is the content of the
    * document when we load it, or since last save.
    */

--- a/src/web/doc/type.ts
+++ b/src/web/doc/type.ts
@@ -1,11 +1,11 @@
 import { Dispatch, SetStateAction } from "react";
 
-interface DocHandleMac {
+export interface DocHandleMac {
   type: "mac";
   path: string;
 }
 
-interface DocHandleWeb {
+export interface DocHandleWeb {
   type: "web";
   handle: FileSystemFileHandle;
 }

--- a/src/web/doc/type.ts
+++ b/src/web/doc/type.ts
@@ -4,7 +4,7 @@ export interface Doc {
   /**
    * null: Not saved yet
    */
-  path: string | null;
+  path?: string | null;
   /**
    * This is like path but for the Web Version.
    * File Access System API is still experimental. 

--- a/src/web/error/message.ts
+++ b/src/web/error/message.ts
@@ -1,0 +1,4 @@
+export const getErrorMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  return "Unknown error";
+};

--- a/src/web/host/get.ts
+++ b/src/web/host/get.ts
@@ -1,0 +1,4 @@
+export const getHost = (): "mac" | "web" => {
+  if ((window as any).webkit !== undefined) return "mac";
+  return "web";
+};

--- a/src/web/host/mac.ts
+++ b/src/web/host/mac.ts
@@ -56,7 +56,7 @@ type Res<T extends Name> = T extends OpenFile.Name
   ? OpenUrl.Res
   : unknown;
 
-export const sendHostMessage = async <T extends Name>(
+export const postMacMessage = async <T extends Name>(
   type: T,
   req: Req<T>
 ): Promise<Res<T>> => {

--- a/src/web/host/open.ts
+++ b/src/web/host/open.ts
@@ -1,0 +1,53 @@
+import { Doc } from "../doc/type";
+import { getHost } from "./get";
+import { postMacMessage } from "./mac";
+
+const openMac = async (): Promise<Doc> => {
+  const { content, path } = await postMacMessage("openFile", {});
+  const doc: Doc = { content, handle: { type: "mac", path } };
+  return doc;
+};
+
+const openWeb = async (): Promise<Doc | null> => {
+  if (window.showOpenFilePicker === undefined) {
+    const msg = [
+      "Your browser does not allow Samuwrite to open local files.",
+      "Please switch to another browser or use the Mac app of Samuwrite.",
+    ].join(" ");
+    throw Error(msg);
+  }
+
+  let handle: FileSystemFileHandle;
+
+  try {
+    const accept = { "text/plain": [".md", ".mdx", ".txt"] };
+    const result = await window.showOpenFilePicker({
+      excludeAcceptAllOption: false,
+      multiple: false,
+      types: [{ description: "Text files", accept }],
+    });
+    handle = result[0];
+  } catch (error: unknown) {
+    // User clicks "Cancel" on the file picker
+    if (error instanceof DOMException && error.code === error.ABORT_ERR)
+      return null;
+    throw error;
+  }
+
+  const file = await handle.getFile();
+  const content = await file.text();
+  const doc: Doc = { content, handle: { type: "web", handle } };
+  return doc;
+};
+
+/**
+ * "null" means safely ignored (e.g. user cancels the request)
+ */
+export const openDoc = async (): Promise<Doc | null> => {
+  switch (getHost()) {
+    case "mac":
+      return openMac();
+    case "web":
+      return openWeb();
+  }
+};

--- a/src/web/host/save.ts
+++ b/src/web/host/save.ts
@@ -1,0 +1,34 @@
+import { DocHandleMac, DocHandleWeb } from "../doc/type";
+import { getHost } from "./get";
+import { postMacMessage } from "./mac";
+
+const saveMac = async (
+  handle: DocHandleMac,
+  content: string
+): Promise<void> => {
+  const { path } = handle;
+  await postMacMessage("saveFile", { path, content });
+};
+
+const saveWeb = async (
+  handle: DocHandleWeb,
+  content: string
+): Promise<void> => {
+  const writable = await handle.handle.createWritable();
+  await writable.write(content);
+  await writable.close();
+};
+
+export const saveDoc = async (
+  handle: DocHandleMac | DocHandleWeb,
+  content: string
+): Promise<void> => {
+  switch (getHost()) {
+    case "mac":
+      if (handle.type === "mac") return saveMac(handle, content);
+      throw Error(`Host is "mac" but handle is "${handle.type}"`);
+    case "web":
+      if (handle.type === "web") return saveWeb(handle, content);
+      throw Error(`Host is "web" but handle is "${handle.type}"`);
+  }
+};

--- a/src/web/menu/link.tsx
+++ b/src/web/menu/link.tsx
@@ -1,6 +1,6 @@
 import { Menu } from "@headlessui/react";
 import { ReactNode } from "react";
-import { sendHostMessage } from "../host/send";
+import { postMacMessage } from "../host/mac";
 import * as s from "./link.module.css";
 
 interface Props {
@@ -18,7 +18,7 @@ export const MenuLink = (props: Props): JSX.Element => {
     return isMac ? (
       <button
         onClick={async () => {
-          await sendHostMessage("openUrl", { url: href });
+          await postMacMessage("openUrl", { url: href });
         }}
         className={className}
       >

--- a/src/web/toolbar/open.tsx
+++ b/src/web/toolbar/open.tsx
@@ -8,8 +8,54 @@ interface Props extends DocState {
   editor: Editor;
 }
 
+const pickerOpts = {
+  types: [
+    {
+      description: "Markdown",
+      accept: {
+        "text/*": [".md"],
+      },
+    },
+  ],
+  excludeAcceptAllOption: true,
+  multiple: false,
+};
+
+// Copied from https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API
+async function getTheFileHandle() {
+  // @ts-ignore open file picker
+  const [fileHandle] = await window.showOpenFilePicker(pickerOpts);
+  if (!fileHandle) return;
+
+  return fileHandle;
+}
+
 const open = async (props: Props): Promise<void> => {
   const { doc, editor, setDoc } = props;
+
+  const isMac = (window as any).webkit !== undefined;
+  if (!isMac) {
+    //@ts-ignore This API is experimental and Typescript doesn't support it yet.
+    const fileHandle = await getTheFileHandle();
+    if (!fileHandle) return;
+
+    const fileBlob: File = await fileHandle.getFile();
+
+    const reader = new FileReader();
+
+    reader.readAsText(fileBlob);
+
+    //@ts-ignore
+    reader.addEventListener("load", () => {
+      editor.setValue(reader.result as string);
+      setDoc({
+        content: reader.result as string,
+        path: fileBlob.name,
+        fileHandle: fileHandle,
+      });
+    });
+    return;
+  }
 
   // Unsaved changes
   if (editor.getValue() !== doc.content) {

--- a/src/web/toolbar/open.tsx
+++ b/src/web/toolbar/open.tsx
@@ -1,71 +1,36 @@
 import { FileDirectoryIcon } from "@primer/octicons-react";
 import { DocState } from "../doc/type";
 import { Editor } from "../editor/type";
-import { sendHostMessage } from "../host/send";
+import { getErrorMessage } from "../error/message";
+import { openDoc } from "../host/open";
 import { ToolbarButton } from "./button/button";
 
 interface Props extends DocState {
   editor: Editor;
 }
 
-const pickerOpts = {
-  types: [
-    {
-      description: "Markdown",
-      accept: {
-        "text/*": [".md"],
-      },
-    },
-  ],
-  excludeAcceptAllOption: true,
-  multiple: false,
-};
-
-// Copied from https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API
-async function getTheFileHandle() {
-  // @ts-ignore open file picker
-  const [fileHandle] = await window.showOpenFilePicker(pickerOpts);
-  if (!fileHandle) return;
-
-  return fileHandle;
-}
-
 const open = async (props: Props): Promise<void> => {
   const { doc, editor, setDoc } = props;
 
-  const isMac = (window as any).webkit !== undefined;
-  if (!isMac) {
-    //@ts-ignore This API is experimental and Typescript doesn't support it yet.
-    const fileHandle = await getTheFileHandle();
-    if (!fileHandle) return;
-
-    const fileBlob: File = await fileHandle.getFile();
-
-    const reader = new FileReader();
-
-    reader.readAsText(fileBlob);
-
-    //@ts-ignore
-    reader.addEventListener("load", () => {
-      editor.setValue(reader.result as string);
-      setDoc({
-        content: reader.result as string,
-        path: fileBlob.name,
-        fileHandle: fileHandle,
-      });
-    });
-    return;
-  }
-
   // Unsaved changes
   if (editor.getValue() !== doc.content) {
-    const confirm = window.confirm("Are you sure?");
+    const msg = [
+      "You have unsaved changes.",
+      "Are you sure you want to open a new file?",
+      "Any unsaved changes will be lost.",
+    ].join(" ");
+    const confirm = window.confirm(msg);
     if (confirm === false) return;
   }
 
-  const response = await sendHostMessage("openFile", {});
-  editor.setValue(response.content);
-  setDoc(response);
+  try {
+    const newDoc = await openDoc();
+    if (newDoc === null) return;
+    editor.setValue(newDoc.content);
+    setDoc(newDoc);
+  } catch (error: unknown) {
+    window.alert(`Cannot open file: ${getErrorMessage(error)}`);
+  }
 };
 
 export const ToolbarOpen = (props: Props): JSX.Element => {

--- a/src/web/toolbar/open.tsx
+++ b/src/web/toolbar/open.tsx
@@ -1,5 +1,5 @@
 import { FileDirectoryIcon } from "@primer/octicons-react";
-import { DocState } from "../doc/type";
+import { Doc, DocState } from "../doc/type";
 import { Editor } from "../editor/type";
 import { getErrorMessage } from "../error/message";
 import { openDoc } from "../host/open";
@@ -23,14 +23,19 @@ const open = async (props: Props): Promise<void> => {
     if (confirm === false) return;
   }
 
+  // Open file from host
+  let newDoc: Doc | null;
   try {
-    const newDoc = await openDoc();
+    newDoc = await openDoc();
     if (newDoc === null) return;
-    editor.setValue(newDoc.content);
-    setDoc(newDoc);
   } catch (error: unknown) {
     window.alert(`Cannot open file: ${getErrorMessage(error)}`);
+    return;
   }
+
+  // Apply
+  editor.setValue(newDoc.content);
+  setDoc(newDoc);
 };
 
 export const ToolbarOpen = (props: Props): JSX.Element => {

--- a/src/web/toolbar/save.tsx
+++ b/src/web/toolbar/save.tsx
@@ -1,7 +1,7 @@
 import { DownloadIcon } from "@primer/octicons-react";
 import { DocState } from "../doc/type";
 import { Editor } from "../editor/type";
-import { sendHostMessage } from "../host/send";
+import { postMacMessage } from "../host/mac";
 import { ToolbarButton } from "./button/button";
 
 interface Props extends DocState {
@@ -15,9 +15,8 @@ const save = async (props: Props): Promise<void> => {
 
   const isMac = (window as any).webkit !== undefined;
   if (!isMac) {
-
     //@ts-ignore This API is experimental and Typescript doesn't support it yet.
-    const fileHandle = doc.fileHandle || await window.showSaveFilePicker();
+    const fileHandle = doc.fileHandle || (await window.showSaveFilePicker());
 
     // create a FileSystemWritableFileStream to write to
     const writableStream = await fileHandle.createWritable();
@@ -33,18 +32,18 @@ const save = async (props: Props): Promise<void> => {
 
     const file: File = await fileHandle.getFile();
 
-    setDoc({ content, fileHandle: fileHandle, path: file.name});
+    setDoc({ content, fileHandle: fileHandle, path: file.name });
 
     return;
   }
 
   if (doc.path === null) {
     // New file
-    const { path } = await sendHostMessage("saveFileAs", { content });
+    const { path } = await postMacMessage("saveFileAs", { content });
     setDoc({ content, path });
   } else {
     // Current file
-    await sendHostMessage("saveFile", { path: doc.path as string, content });
+    await postMacMessage("saveFile", { path: doc.path as string, content });
     setDoc({ ...doc, content });
   }
 };

--- a/src/web/toolbar/save.tsx
+++ b/src/web/toolbar/save.tsx
@@ -17,7 +17,7 @@ const save = async (props: Props): Promise<void> => {
   if (!isMac) {
 
     //@ts-ignore This API is experimental and Typescript doesn't support it yet.
-    const fileHandle = doc.fileHandle ||await window.showSaveFilePicker();
+    const fileHandle = doc.fileHandle || await window.showSaveFilePicker();
 
     // create a FileSystemWritableFileStream to write to
     const writableStream = await fileHandle.createWritable();
@@ -31,7 +31,9 @@ const save = async (props: Props): Promise<void> => {
     // close the file and write the contents to disk.
     await writableStream.close();
 
-    setDoc({ content, fileHandle: fileHandle });
+    const file: File = await fileHandle.getFile();
+
+    setDoc({ content, fileHandle: fileHandle, path: file.name});
 
     return;
   }
@@ -42,7 +44,7 @@ const save = async (props: Props): Promise<void> => {
     setDoc({ content, path });
   } else {
     // Current file
-    await sendHostMessage("saveFile", { path: doc.path, content });
+    await sendHostMessage("saveFile", { path: doc.path as string, content });
     setDoc({ ...doc, content });
   }
 };

--- a/src/web/toolbar/save.tsx
+++ b/src/web/toolbar/save.tsx
@@ -13,6 +13,29 @@ const save = async (props: Props): Promise<void> => {
 
   const content = editor.getValue();
 
+  const isMac = (window as any).webkit !== undefined;
+  if (!isMac) {
+
+    //@ts-ignore This API is experimental and Typescript doesn't support it yet.
+    const fileHandle = doc.fileHandle ||await window.showSaveFilePicker();
+
+    // create a FileSystemWritableFileStream to write to
+    const writableStream = await fileHandle.createWritable();
+
+    // create blog from content
+    const contentBlob = new Blob([content]);
+
+    // write our file
+    await writableStream.write(contentBlob);
+
+    // close the file and write the contents to disk.
+    await writableStream.close();
+
+    setDoc({ content, fileHandle: fileHandle });
+
+    return;
+  }
+
   if (doc.path === null) {
     // New file
     const { path } = await sendHostMessage("saveFileAs", { content });


### PR DESCRIPTION
# Overview
I implemented the save system for the web version using the experimental [File System Access API](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API).

## Demo
### Verel Preview
https://rosepine-git-fork-osmium-dev-main-thien-do.vercel.app/
### Video
https://user-images.githubusercontent.com/99157490/186921166-153f3c73-a9f5-40cc-a784-414bebc12cf9.mp4

## How to use.
This feature is experimental so you will have to enable it. Also, the API requires SSL, so you must either add SSL to your localhost or use something like [localtunnel](https://theboroer.github.io/localtunnel-www/) or [ngrok](https://ngrok.com/).
In other words:
- Enable the File System Access Flag (chrome://flags/#file-system-access-api)
- Add SSL to localhost ([tuto](https://www.section.io/engineering-education/how-to-get-ssl-https-for-localhost/))
or
- Use [localtunnel](https://theboroer.github.io/localtunnel-www/) or [ngrok](https://ngrok.com/).