### PR TITLE
feat(web): Sync preview scroll with current editor position

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@radix-ui/react-switch": "1.0.0",
         "@radix-ui/react-tooltip": "1.0.0",
         "@rose-pine/palette": "3.0.1",
+        "lodash.debounce": "^4.0.8",
         "monaco-editor": "0.31.0",
         "monaco-vim": "0.3.4",
         "react": "18.2.0",
@@ -33,6 +34,7 @@
       },
       "devDependencies": {
         "@parcel/transformer-sass": "2.7.0",
+        "@types/lodash.debounce": "^4.0.7",
         "@types/react": "18.0.18",
         "@types/react-dom": "18.0.6",
         "@types/wicg-file-system-access": "2020.9.5",
@@ -2471,6 +2473,21 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.185",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.185.tgz",
+      "integrity": "sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==",
+      "dev": true
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.7.tgz",
+      "integrity": "sha512-X1T4wMZ+gT000M2/91SYj0d/7JfeNZ9PeeOldSNoE/lunLeQXKvkmIumI29IaKMotU/ln/McOIvgzZcQ/3TrSA==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/mdast": {
       "version": "3.0.10",
@@ -5133,6 +5150,11 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -9855,6 +9877,21 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "@types/lodash": {
+      "version": "4.14.185",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.185.tgz",
+      "integrity": "sha512-evMDG1bC4rgQg4ku9tKpuMh5iBNEwNa3tf9zRHdP1qlv+1WUg44xat4IxCE14gIpZRGUUWAx2VhItCZc25NfMA==",
+      "dev": true
+    },
+    "@types/lodash.debounce": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.7.tgz",
+      "integrity": "sha512-X1T4wMZ+gT000M2/91SYj0d/7JfeNZ9PeeOldSNoE/lunLeQXKvkmIumI29IaKMotU/ln/McOIvgzZcQ/3TrSA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/mdast": {
       "version": "3.0.10",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.10.tgz",
@@ -11712,6 +11749,11 @@
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@parcel/transformer-sass": "2.7.0",
+    "@types/lodash.debounce": "^4.0.7",
     "@types/react": "18.0.18",
     "@types/react-dom": "18.0.6",
     "@types/wicg-file-system-access": "2020.9.5",
@@ -33,6 +34,7 @@
     "@radix-ui/react-switch": "1.0.0",
     "@radix-ui/react-tooltip": "1.0.0",
     "@rose-pine/palette": "3.0.1",
+    "lodash.debounce": "^4.0.8",
     "monaco-editor": "0.31.0",
     "monaco-vim": "0.3.4",
     "react": "18.2.0",

--- a/src/web/preview/preview.tsx
+++ b/src/web/preview/preview.tsx
@@ -5,6 +5,7 @@ import { usePreviewHtml } from "./html";
 import * as s from "./preview.module.css";
 import * as sCard from "../card/card.module.css";
 import { Scroll } from "../scroll/scroll";
+import { usePreviewScroll } from "./state/scroll";
 
 interface Props {
   editor: Editor;
@@ -15,6 +16,7 @@ export const Preview = (props: Props): JSX.Element => {
   const { editor, settings } = props;
 
   const html = usePreviewHtml({ editor });
+  const contentRef = usePreviewScroll({ editor });
 
   return (
     <Scroll>

--- a/src/web/preview/preview.tsx
+++ b/src/web/preview/preview.tsx
@@ -14,9 +14,9 @@ interface Props {
 
 export const Preview = (props: Props): JSX.Element => {
   const { editor, settings } = props;
-
   const html = usePreviewHtml({ editor });
-  const contentRef = usePreviewScroll({ editor });
+
+  usePreviewScroll({ editor });
 
   return (
     <Scroll>

--- a/src/web/preview/state/scroll.ts
+++ b/src/web/preview/state/scroll.ts
@@ -1,0 +1,38 @@
+import { useRef, useMemo, useEffect } from "react";
+import debounce from "lodash.debounce";
+
+import { Editor } from "../../editor/type";
+
+interface Params {
+  editor: Editor;
+}
+type Ref = React.RefObject<HTMLDivElement>;
+
+const scrollPreview = (editor: Editor): void => {
+  const [visibleRange] = editor.getVisibleRanges();
+  const visibleStartLine = visibleRange.startLineNumber;
+
+  const previewEl = document.querySelector(`[data-line="${visibleStartLine}"]`);
+  previewEl?.scrollIntoView({
+    block: visibleStartLine === 1 ? "center" : "start",
+    behavior: "smooth",
+  });
+};
+
+export const usePreviewScroll = (params: Params): Ref => {
+  const { editor } = params;
+  const contentRef = useRef<HTMLDivElement | null>(null);
+
+  const listener: null | (() => void) = useMemo(() => {
+    if (editor === null) return null;
+    return debounce(() => scrollPreview(editor), 100);
+  }, [editor]);
+
+  useEffect(() => {
+    if (editor === null || listener === null) return;
+    const disposable = editor.onDidScrollChange(listener);
+    return () => disposable.dispose();
+  }, [editor, listener]);
+
+  return contentRef;
+};

--- a/src/web/preview/state/scroll.ts
+++ b/src/web/preview/state/scroll.ts
@@ -19,9 +19,8 @@ const scrollPreview = (editor: Editor): void => {
   });
 };
 
-export const usePreviewScroll = (params: Params): Ref => {
+export const usePreviewScroll = (params: Params) => {
   const { editor } = params;
-  const contentRef = useRef<HTMLDivElement | null>(null);
 
   const listener: null | (() => void) = useMemo(() => {
     if (editor === null) return null;
@@ -33,6 +32,4 @@ export const usePreviewScroll = (params: Params): Ref => {
     const disposable = editor.onDidScrollChange(listener);
     return () => disposable.dispose();
   }, [editor, listener]);
-
-  return contentRef;
 };


### PR DESCRIPTION
- [x] Sync preview scroll with current editor position 
  - [x] usePreviewScroll hook: receive `editor` param from Preview component, pass to `scrollPreview` function
  - [x] scrollPreview function: get editor's current visible ranges by using monaco-editor built-in `getVisibleRanges()` method that contains the data of start line of visible range then select element that contains the attribute `data-line` that equals to the retrieved start line and scroll into view